### PR TITLE
[HOTFIX]: empty collectionViewCell 리턴해결

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - name: Checkout
-    	uses: actions/checkout@v3
-    - name: Xcode Build Test
-      run: xcodebuild clean test -project Netflix.xcodeproj -scheme "Netflix" -destination "platform=iOS Simulator,name=iPhone 13 Pro,OS=15.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set Default Scheme
+        run: xcodebuild clean test -project Netflix.xcodeproj -scheme "Netflix" -destination "platform=iOS Simulator,name=iPhone 13 Pro,OS=15.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,9 +8,11 @@ on:
 
 jobs:
   build:
+		name: Xcode build Test And Netflix Test
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+    	uses: actions/checkout@v3
     - name: Xcode Build Test
       run: xcodebuild clean test -project Netflix.xcodeproj -scheme "Netflix" -destination "platform=iOS Simulator,name=iPhone 13 Pro,OS=15.2" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-		name: Xcode build Test
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-		name: Xcode build Test And Netflix Test
+    name: Xcode build Test And Netflix Test
     runs-on: macos-latest
 
     steps:

--- a/Netflix.xcodeproj/xcuserdata/yudonlee.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Netflix.xcodeproj/xcuserdata/yudonlee.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -36,5 +36,101 @@
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "6B3639C4-EDB8-4A1B-B117-B09500635D3F"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Netflix/Views/CollectionViewTableViewCell.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "56"
+            endingLineNumber = "56"
+            landmarkName = "configure(with:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "9F87D47C-A4A6-42BC-A0F3-D2E3404DCF5A"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Netflix/Controllers/Core/HomeViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "148"
+            endingLineNumber = "148"
+            landmarkName = "tableView(_:cellForRowAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "E65AFF07-DBA5-409C-8E99-2EBAC497EBF6"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Netflix/Views/CollectionViewTableViewCell.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "91"
+            endingLineNumber = "91"
+            landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "9688D2F0-8EF9-4862-8159-685D47EE028F"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Netflix/Views/TitleCollectionViewCell.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "41"
+            endingLineNumber = "41"
+            landmarkName = "configure(with:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "C8D656D5-3C1F-4A67-9516-44E52A58F333"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Netflix/Views/CollectionViewTableViewCell.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "92"
+            endingLineNumber = "92"
+            landmarkName = "collectionView(_:cellForItemAt:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "BE32E207-A0C7-4507-98A9-F81A8BD6A1E5"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Netflix/Views/CollectionViewTableViewCell.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "59"
+            endingLineNumber = "59"
+            landmarkName = "configure(with:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/Netflix/Managers/APICaller.swift
+++ b/Netflix/Managers/APICaller.swift
@@ -190,8 +190,6 @@ class APICaller {
     }
 }
 
-
-
 //\(Constants.baseURL)/3/movie/upcoming?api_key=(Constants.API_KEY)&language=ko-KR&page=1
 
 //https://api.themoviedb.org/3/discover/movie?api_key=4a09916eaf1807f253b181e44cbc3adc&language=ko-KR&sort_by=popularity.desc&include_adult=false&include_video=false&page=1&with_watch_monetization_types=flatrate

--- a/Netflix/Views/CollectionViewTableViewCell.swift
+++ b/Netflix/Views/CollectionViewTableViewCell.swift
@@ -26,6 +26,8 @@ class CollectionViewTableViewCell: UITableViewCell {
 //        왜 zero를 해주는걸까?
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(TitleCollectionViewCell.self, forCellWithReuseIdentifier: TitleCollectionViewCell.identifier)
+        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "default")
+        
         return collectionView
     }()
     
@@ -51,7 +53,9 @@ class CollectionViewTableViewCell: UITableViewCell {
     }
     
     func configure(with titles: [Title]) {
-        self.titles = titles
+        self.titles = titles.filter { title in
+            title.poster_path != nil
+        }
 //        main thread에서 reload해야하기 때문에, async를 해주었다.
         
         DispatchQueue.main.async {
@@ -82,8 +86,11 @@ extension CollectionViewTableViewCell: UICollectionViewDelegate, UICollectionVie
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TitleCollectionViewCell.identifier, for: indexPath) as? TitleCollectionViewCell else {
             return UICollectionViewCell()
         }
-//        cell.backgroundColor = .green
-        guard let model = titles[indexPath.row].poster_path else { return UICollectionViewCell() }
+        
+//      poster path가 empty시 빈 UICollectionViewCell을 리턴해주도록 해 crash 방지
+        guard let model = titles[indexPath.row].poster_path else {
+            return collectionView.dequeueReusableCell(withReuseIdentifier: "default", for: indexPath)
+        }
         cell.configure(with: model)
         return cell
     }

--- a/Netflix/Views/TitleCollectionViewCell.swift
+++ b/Netflix/Views/TitleCollectionViewCell.swift
@@ -37,7 +37,10 @@ class TitleCollectionViewCell: UICollectionViewCell {
     }
     
     public func configure(with model: String) {
-        guard let url = URL(string: "https://image.tmdb.org/t/p/w500/\(model)") else { return }
+        guard let url = URL(string: "https://image.tmdb.org/t/p/w500/\(model)") else {
+            return
+            
+        }
 //        kingfihser가 메모리는 더 많이 쓰는듯 하다 200MB
         posterImageView.kf.setImage(with: url)
 //      130MB


### PR DESCRIPTION
## 🍑 관련 이슈

#7 
## 🍑 구현/변경 사항 및 이유
### 1. CollectionView Crush 이유 
CollectionView에 custom cell을 사용중 Datasource부분중 cell에 넣는 데이터에서 특정 조건을 만족할 시 dequeue한 custom cell대신 guard let으로 return UICollectionViewCell()을 하고 있습니다.
근데 해당 부분때문에 앱이 크러시가 났다. 
### 2. 임시 해결책 
하지만 collectionview에 UICollectionViewCell을 register해도 문제가 발생하였다. 

### 3. 최종해결책 
```swift
return  collectionView.dequeueReusableCell(withReuseIdentifier: "default", for: indexPath)
``` 

### 4. 이유 
```swift  
return UICollectionViewCell()
```
```swift
return collectionView.dequeueReusableCell(withReuseIdentifier: "default", for: indexPath)
```
두 statement가 동일하다고 생각했는데 내부가 디버깅을 해보니 내부 리소스가 달랐으며 reuseIdentifier의 값이 기존에 register에 된 값이여야 crush가 발생되지 않는다.


## 🍑 참고 사항
|                                            UICollectionViewCell()                                             |                                            collectionView.dequeueReusableCell(withReuseIdentifier: "default", for: indexPath)                                             |
| :--------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------: |
| ![UICOllectionViewCell1](https://user-images.githubusercontent.com/39371835/196933482-e5648253-de57-4742-ab24-a954a27cab90.png) | ![Untitled](https://user-images.githubusercontent.com/39371835/196933551-08312428-137b-4d03-8902-86dbfb541cac.png) |

## 참고링크 
https://stackoverflow.com/questions/69046437/unexpected-crash-in-collectionview-ios

